### PR TITLE
Pdf change

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 rand = "0.8.5"
 rand_pcg = "0.3.1"
+ndarray="0.15.6"
 approx = {version = "0.5", features = ["num-complex"]}
 
 

--- a/src/gradient.rs
+++ b/src/gradient.rs
@@ -48,7 +48,7 @@ mod test {
     use std::collections::HashMap;
 
     fn functional<T: Eq + Hash>(pdf: &PDF<T>) -> f32 {
-        return pdf.map.values().map(|s| s.powi(2)).sum();
+        return pdf.prob.map(|s| s.powi(2)).sum();
     }
 
     #[test]


### PR DESCRIPTION
pdf를 hash_map으로만 구현하는 것은 이후 probability를 수정하거나, gradient를 계산하는데 어려움을 만들 수 있다. 
따라서 hash_map은 key와 index 사이 mapping을 위해서만 남기고, probability vector는 ndarray::Array1의 구조로 변경하였다. 